### PR TITLE
journeys - add a text field to forward schenario param

### DIFF
--- a/assets/js/journey.js
+++ b/assets/js/journey.js
@@ -347,6 +347,8 @@ function journey_onLoad() {
 		if (t["datetime_represents"]=="arrival") {document.getElementById("datetime_represents_a").checked=true;}
 	}
 
+	document.getElementById("custom_scenario").value = (t["custom_scenario"])?t["custom_scenario"]:"";
+
 
 	map = L.map('map-canvas').setView([48.837212, 2.413], 8);
 	// add an OpenStreetMap tile layer
@@ -459,6 +461,11 @@ function getItinerary(){
 		var forbidden_uri = journey.forbidden_uris_list[i];
 		url+="&forbidden_uris[]="+forbidden_uri;
 	}
+
+    custom_scenario = t["custom_scenario"]
+    if (custom_scenario) {
+        url+="&_override_scenario="+custom_scenario
+    }
 	
 	callNavitia(document.getElementById("ws_name").value, url, function(response){
 		journey.journey_list=response.journeys;

--- a/journey.html
+++ b/journey.html
@@ -53,6 +53,9 @@
 							<input type="checkbox" name="last_section_mode" id="last_section_mode_bss" value="bss">Arrivée en VLS<br>
 							<input type="checkbox" name="last_section_mode" id="last_section_mode_car" value="car">Arrivée en voiture<br>
 						</td>
+						<td valign="top" style="font-size:10px">
+							Scenario <input type="text" name="custom_scenario" id="custom_scenario" value=""><br>
+						</td>
 					</tr>
 					<tr>
 						<td colspan="3" align="center">


### PR DESCRIPTION
Add a simple text field to choose the navitia scenario used.

this param will be quite useful for the tests of the new navitia scenario.

I think this should be hidden a bit not to confuse the user, but for the moment it is easier to add it to the default panel.