### PR TITLE
afficher l'erreur navitia même lorsqu'elle n'est pas à l'intérieur d'…

### DIFF
--- a/assets/js/journey.js
+++ b/assets/js/journey.js
@@ -28,9 +28,10 @@ function clearMap(){
 
 function getJourneyListHtml(){
 	str="";
+	console.log(journey)
 	if (journey.journey_error) {
-		str+="error_id:" + journey.journey_error.id + "<br>";
-		str+="error_message:" + journey.journey_error.message + "<br>";
+		str+="error_id: " + journey.journey_error.id + "<br>";
+		str+="error_message: " + journey.journey_error.message + "<br>";
 	}
 	for (var i in journey.journey_list){
 		str+='<div id="jo'+i+'" class="journey">';
@@ -469,7 +470,8 @@ function getItinerary(){
 	
 	callNavitia(document.getElementById("ws_name").value, url, function(response){
 		journey.journey_list=response.journeys;
-		journey.journey_error=response.error;
+        if (response.message) {journey.journey_error={'id' : '(aucun id navitia)', 'message' : response.message}}
+		else {journey.journey_error=response.error};
 		journey.journey_url=response.url;
 		getJourneyListHtml();
 	});

--- a/assets/js/journey.js
+++ b/assets/js/journey.js
@@ -28,7 +28,6 @@ function clearMap(){
 
 function getJourneyListHtml(){
 	str="";
-	console.log(journey)
 	if (journey.journey_error) {
 		str+="error_id: " + journey.journey_error.id + "<br>";
 		str+="error_message: " + journey.journey_error.message + "<br>";
@@ -470,8 +469,14 @@ function getItinerary(){
 	
 	callNavitia(document.getElementById("ws_name").value, url, function(response){
 		journey.journey_list=response.journeys;
-        if (response.message) {journey.journey_error={'id' : '(aucun id navitia)', 'message' : response.message}}
-		else {journey.journey_error=response.error};
+		if (response.message) {
+            journey.journey_error = {
+                'id' : '(aucun id navitia)', 
+                'message' : response.message
+            };
+        } else {
+            journey.journey_error = response.error;
+        }
 		journey.journey_url=response.url;
 		getJourneyListHtml();
 	});


### PR DESCRIPTION
…un objet error

Parfois, en cas d'erreur 400 (par exemple, si on passe n'importe quoi dans le champ scenario), l'erreur navitia est retournée uniquement dans un objet message.
Elle n'était alors pas affichée dans l'ihm de diagnostic.