### PR TITLE
rendre explicite la valeur par défaut de datetime_represents

### DIFF
--- a/journey.html
+++ b/journey.html
@@ -30,7 +30,7 @@
 						<td >
 							date : <input type="texte" id="date" name="date" size="5"><br>
 							heure : <input type="texte" id="time" name="time" size="1"><br>
-							Partir après<input type="radio" id="datetime_represents_d" name="datetime_represents" value="departure"><br>
+							Partir après<input type="radio" id="datetime_represents_d" name="datetime_represents" value="departure" checked="true"><br>
 							Arriver avant<input type="radio" id="datetime_represents_a" name="datetime_represents" value="arrival">
 
 						</td>


### PR DESCRIPTION
Pas sûre que ça soit pertinent.

Mais je trouve ça étrange que rien ne soit sélectionné par défaut. D'autant plus qu'il y a une valeur par défaut dans navitia.