### PR TITLE
exploration - refonte du design

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -67,6 +67,9 @@ h2{
     text-align : center;
     font-size: 14px;
 }
+h1{
+    text-align : center;
+}
 /*style pour virer les tableaux */
 section {
     display: inline-block;

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -1,4 +1,4 @@
-body {font-size: 62.5%;
+body {font-size: 12px;
     font-family: "Trebuchet MS", "Helvetica", "Arial",  "Verdana", "sans-serif";
 }
 ul.title {
@@ -60,6 +60,10 @@ ul li a:hover {
 }
 
 .footer{
+    text-align : center;
+    font-size: 14px;
+}
+h2{
     text-align : center;
     font-size: 14px;
 }

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -70,26 +70,39 @@ h2{
 h1{
     text-align : center;
 }
+
 /*style pour virer les tableaux */
 section {
     display: inline-block;
     vertical-align: top;
-    max-width : 600px;
+    width : 49%;
+    margin : auto;
 }
 
 section.first_half {
     min-width: 500px;
     max-height : 500px;
     overflow-y: scroll;
+    border-style: solid;
+    border-width: 0px;
+}
+section.second_half {
+    min-width: 500px;
+    max-height : 500px;
+    padding-left: 2px;
 }
  
+ 
 .map-canvas {
-    height : 500px;
-    width: 500px;
+    height : 100%;
+    width: 100%;
+    max-height : 500px;
 }
 .item{
     padding:5px;
     font-size: 12px;
+    border-width: 1px;
+    border-style: none none solid none;
 }
 
 .item .title {

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -63,3 +63,20 @@ ul li a:hover {
     text-align : center;
     font-size: 14px;
 }
+/*style pour virer les tableaux */
+section {
+  display: inline-block;
+  vertical-align: top;
+  max-width : 600px;
+  border:6px solid #949599;
+}
+
+section.first_half {
+ max-height : 500px;
+ overflow-y: scroll;
+ }
+ 
+.map-canvas {
+    height : 500px;
+    width: 500px;
+}

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -65,18 +65,34 @@ ul li a:hover {
 }
 /*style pour virer les tableaux */
 section {
-  display: inline-block;
-  vertical-align: top;
-  max-width : 600px;
-  border:6px solid #949599;
+    display: inline-block;
+    vertical-align: top;
+    max-width : 600px;
 }
 
 section.first_half {
- max-height : 500px;
- overflow-y: scroll;
- }
+    min-width: 500px;
+    max-height : 500px;
+    overflow-y: scroll;
+}
  
 .map-canvas {
     height : 500px;
     width: 500px;
+}
+.item{
+    padding:5px;
+    font-size: 12px;
+}
+
+.item .title {
+    display:block;
+    color: #EA6612  ;
+    font-weight:700;
+}
+.item .title small { font-weight:400; }
+.item.active .title,
+.item .title:hover { color:#BAB431; }
+.item .active {
+background-color:#f8f8f8;
 }

--- a/assets/js/places_nearby.js
+++ b/assets/js/places_nearby.js
@@ -1,11 +1,3 @@
-function onMapClick(e) {
-    popup
-        .setLatLng(e.latlng)
-        .setContent("LatLon : " + e.latlng.lat + ", "+e.latlng.lng)
-        .openOn(map);
-}
-
-
 function show_places_html(){
     str='<table style="font-size:11px"><tr>';
     str+='<th>Type</th>';
@@ -58,12 +50,12 @@ function getPlacesNearby(uri, distance){
         }
         callNavitiaJS(ws_name, url, '', function(response){
             if (response.places_nearby) {
-                places_nearby = response.places_nearby; 
+                places_nearby = response.places_nearby;
                 show_places_html();
                 show_places_on_map();
             }
         });
-    
+
 }
 
 function places_nearby_onLoad(){

--- a/assets/js/places_nearby.js
+++ b/assets/js/places_nearby.js
@@ -1,19 +1,19 @@
 function show_places_html(){
     str='<table style="font-size:11px"><tr>';
-    str+='<th>Type</th>';
-    str+='<th>Object</th>';
     str+='<th>Distance</th>';
+    str+='<th>Type</th>';
+    str+='<th>Objet</th>';
     str+='</tr>';
     for (var i in places_nearby){
         n=places_nearby[i];
         s_str="<tr>";
+        s_str+='<td>'+n.distance + "</td>";
         if (n.embedded_type=="poi") {
             s_str+='<td>'+n.poi.poi_type.name + "</td>";
         } else {
             s_str+='<td>'+n.embedded_type + "</td>";
         }
         s_str+='<td>'+n.name + "</td>";
-        s_str+='<td>'+n.distance + "</td>";
         s_str+="</tr>\n";
         str+=s_str;
     }
@@ -75,7 +75,6 @@ function places_nearby_onLoad(){
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(map);
     L.control.scale().addTo(map);
-    map.on('click', onMapClick);
  }
 
 $(document).ready(function(){

--- a/assets/js/ptref.js
+++ b/assets/js/ptref.js
@@ -158,35 +158,28 @@ function showNetworksHtml(){
         item.className = 'item';
         item.innerHTML = "<a class='title'>" + n.name + "</a>";
         item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br><a href='"+getNewURI('/physical_modes/', true, n.id)+"' > Modes Ph </a>"  
+        item.innerHTML += "<br><a href='"+getNewURI('/physical_modes/', true, n.id)+"' > Modes Ph </a>"
         item.innerHTML += "- <a href='"+getNewURI('/commercial_modes/', true, n.id)+"' >Modes co </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"
         item.innerHTML += "- <a href='"+getNewURI('/stop_areas/', true, n.id)+"' > Zones d'arrêts </a>"
         worst_disruption = getWorstDisruption(n.links);
         item.innerHTML += getSeverityIcon(worst_disruption);
-    } 
+    }
 }
 
 
 function showCalendarsHtml(){
-    str="";
-    str+='<table><tr>';
-    str+='<th>Id (Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count + ')</th>';
-    str+='<th>Name</th>';
-    str+='<th>Explorer</th>';
-    str+='</tr>';
+    var ptref_div = document.getElementById('ptref_content');
+    var total = ptref_div.appendChild(document.createElement('div'));
+    total.textContent = 'Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count ;
     for (var i in ptref.object_list){
-        n=ptref.object_list[i];
-        s_str="<tr>";
-        s_str+='<td><a href="'+getNewURI('/calendars/'+n.id+'/', false, n.id)+'">'+n.id+'</a></td>';
-        title = calendar_to_str(n);
-        s_str+='<td><span title="'+title+'">'+n.name + "</span></td>";
-        s_str+='<td><a href="'+getNewURI('/lines/', true, n.id)+'">Lines</a></td>';
-        s_str+="</tr>\n";
-        str+=s_str;
+      n=ptref.object_list[i];
+      var item = ptref_div.appendChild(document.createElement('div'));
+      item.className = 'item';
+      item.innerHTML = "<a class='title'>" + n.name + "</a>";
+      item.innerHTML += "<small>" + n.id + "</small>";
+      item.innerHTML += "<br><a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"
     }
-    str+='</table>'
-    document.getElementById('ptref_content').innerHTML=str;
 }
 
 function showTrafficReportsHtml(){
@@ -315,10 +308,10 @@ function showModesHtml(){
         item.className = 'item';
         item.innerHTML = "<a class='title'>" + n.name + "</a>";
         item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br><a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"  
+        item.innerHTML += "<br><a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"
         worst_disruption = getWorstDisruption(n.links);
         item.innerHTML += getSeverityIcon(worst_disruption);
-    } 
+    }
 }
 
 function showStopAreasHtml(){
@@ -333,15 +326,15 @@ function showStopAreasHtml(){
         item.className = 'item';
         item.innerHTML = "<a class='title' id='item_"+n.id+"' onclick='zoom_to_item("+coord.lat+","+coord.lon+", \""+n.id +"\")'>" + n.label + "</a>";
         item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br><a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"  
+        item.innerHTML += "<br><a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"
         item.innerHTML += "- <a href='"+getNewURI('/stop_points/', true, n.id)+"' >Points d'arrêts </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/connections/', true, n.id)+"' > Correspondances </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/connections/', true, n.id)+"' > Correspondances </a>"
         item.innerHTML += "- <a href='"+getNewURI('/departures/', true, n.id)+"' > Prochains départs </a>"
         item.innerHTML += "- <a href='stop_schedules.html?ws_name="+ws_name+"&coverage="+coverage+"&stop_area_id="+n.id+"' > Horaires </a>"
         item.innerHTML += "- <a href='"+getNewURI('/places_nearby/', true, n.id)+"' > Autour </a>"
         worst_disruption = getWorstDisruption(n.links);
         item.innerHTML += getSeverityIcon(worst_disruption);
-                    
+
         n.marker = L.marker([coord.lat, coord.lon]);
         lamb=WGS_ED50(coord.lon, coord.lat);
         try {
@@ -352,15 +345,15 @@ function showStopAreasHtml(){
         }
 
         n.marker.item_id = "item_" + n.id;
-        
+
         n.marker.on('click', function(e) {
             map.panTo([e.latlng.lat, e.latlng.lng]);
             item = document.getElementById(this.item_id);
             setActive(item);
             item.scrollIntoView();
         });
-        
-            
+
+
         n.marker.bindPopup(
             "<b>"+n.name+"</b>"+
             "<br />"+s_city+
@@ -368,10 +361,10 @@ function showStopAreasHtml(){
             "<br />LatLon wgs84: "+coord.lat + ", "+ coord.lon+
             "<br />LatLon l2E: "+lamb[0] + ", "+ lamb[1]
         );
-        
+
         map.addLayer(n.marker);
         newBounds.push([coord.lat, coord.lon]);
-        
+
     }
     if (newBounds) {map.fitBounds(newBounds)};
 }
@@ -388,11 +381,11 @@ function showStopPointsHtml(){
         item.className = 'item';
         item.innerHTML = "<a class='title' id='item_"+n.id+"' onclick='zoom_to_item("+coord.lat+","+coord.lon+", \""+n.id +"\")'>" + n.label + "</a>";
         item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br><a href='"+getNewURI('/routes/', true, n.id)+"' > Parcours </a>"  
+        item.innerHTML += "<br><a href='"+getNewURI('/routes/', true, n.id)+"' > Parcours </a>"
         item.innerHTML += "- <a href='"+getNewURI('/stop_areas/', true, n.id)+"' >Zones d'arrêts </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/connections/', true, n.id)+"' > Correspondances </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/connections/', true, n.id)+"' > Correspondances </a>"
         item.innerHTML += "- <a href='"+getNewURI('/places_nearby/', true, n.id)+"' > Autour </a>"
-                    
+
         n.marker = L.marker([coord.lat, coord.lon]);
         lamb=WGS_ED50(coord.lon, coord.lat);
         try {
@@ -403,15 +396,15 @@ function showStopPointsHtml(){
         }
 
         n.marker.item_id = "item_" + n.id;
-        
+
         n.marker.on('click', function(e) {
             map.panTo([e.latlng.lat, e.latlng.lng]);
             item = document.getElementById(this.item_id);
             setActive(item);
             item.scrollIntoView();
         });
-        
-            
+
+
         n.marker.bindPopup(
             "<b>"+n.name+"</b>"+
             "<br />"+s_city+
@@ -419,10 +412,10 @@ function showStopPointsHtml(){
             "<br />LatLon wgs84: "+coord.lat + ", "+ coord.lon+
             "<br />LatLon l2E: "+lamb[0] + ", "+ lamb[1]
         );
-        
+
         map.addLayer(n.marker);
         newBounds.push([coord.lat, coord.lon]);
-        
+
     }
     if (newBounds) {map.fitBounds(newBounds)};
 }
@@ -499,7 +492,7 @@ function showPOIsHtml(){
         item.innerHTML += "<small>" + n.id + "</small>";
         item.innerHTML += "<br> <a href='"+getNewURI('/places_nearby/', true, n.id)+"' > Autour </a>"
 
-                    
+
         n.marker = L.marker([coord.lat, coord.lon]);
         lamb=WGS_ED50(coord.lon, coord.lat);
         try {
@@ -510,15 +503,15 @@ function showPOIsHtml(){
         }
 
         n.marker.item_id = "item_" + n.id;
-        
+
         n.marker.on('click', function(e) {
             map.panTo([e.latlng.lat, e.latlng.lng]);
             item = document.getElementById(this.item_id);
             setActive(item);
             item.scrollIntoView();
         });
-        
-            
+
+
         n.marker.bindPopup(
             "<b>"+n.name+"</b>"+
             "<br />"+s_city+
@@ -526,13 +519,13 @@ function showPOIsHtml(){
             "<br />LatLon wgs84: "+coord.lat + ", "+ coord.lon+
             "<br />LatLon l2E: "+lamb[0] + ", "+ lamb[1]
         );
-        
+
         map.addLayer(n.marker);
         newBounds.push([coord.lat, coord.lon]);
-        
+
     }
     if (newBounds) {map.fitBounds(newBounds)};
-    
+
 }
 
 function showPoiTypesHtml(){
@@ -546,8 +539,8 @@ function showPoiTypesHtml(){
         item.className = 'item';
         item.innerHTML = "<a class='title'>" + n.name + "</a>";
         item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br><a href='"+getNewURI('/pois/', true, n.id)+"' > POIs </a>"  
-    } 
+        item.innerHTML += "<br><a href='"+getNewURI('/pois/', true, n.id)+"' > POIs </a>"
+    }
 }
 
 function setConnectionFilter(){
@@ -669,9 +662,10 @@ function showLinesHtml(){
         item.className = 'item';
         item.innerHTML = "<a class='title' id='item_"+n.id+"' onclick='setActive(this)'><span class='icon-ligne' style='background-color: #"+n.color+";'>"+n.code + "</span> : " + n.name + "</a>";
         item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br><a href='"+getNewURI('/physical_modes/', true, n.id)+"' > Modes Ph </a>"  
+        item.innerHTML += "<br><a href='"+getNewURI('/physical_modes/', true, n.id)+"' > Modes Ph </a>"
         item.innerHTML += "- <a href='"+getNewURI('/commercial_modes/', true, n.id)+"' >Modes co </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/stop_areas/', true, n.id)+"' > Zones d'arrêts </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/calendars/', true, n.id)+"' > Calendriers </a>"
+        item.innerHTML += "- <a href='"+getNewURI('/stop_areas/', true, n.id)+"' > Zones d'arrêts </a>"
         item.innerHTML += "- <a href='"+getNewURI('/routes/', true, n.id)+"' > Parcours </a>"
         worst_disruption = getWorstDisruption(n.links);
         item.innerHTML += getSeverityIcon(worst_disruption);
@@ -691,7 +685,7 @@ function showLinesHtml(){
             else {newBounds=newBounds.extend(n.layer.getBounds());}
         }
     }
-    if (newBounds) {map.fitBounds(newBounds)}; 
+    if (newBounds) {map.fitBounds(newBounds)};
 }
 
 function showVehicleJourneysHtml(){
@@ -712,7 +706,7 @@ function showVehicleJourneysHtml(){
         for (var j in n.calendars){
             c = n.calendars[j];
             hint = calendar_to_str(c);
-            if (j > 0) s_str+= "<br>";  
+            if (j > 0) s_str+= "<br>";
             label = calendar_operating_days_to_str(c);
             s_str+='<span title="'+hint+'">'+ label + "</span>";
         }
@@ -740,7 +734,7 @@ function showRoutesHtml(){
         item.innerHTML = "<a class='title' id='item_"+n.id+"' onclick='setActive(this)'><span class='icon-ligne' style='background-color: #"+n.line.color+";'>"+n.line.code + "</span> : " + n.name + "</a>";
         item.innerHTML += "<small>" + n.id + "</small>";
         item.innerHTML += "<br><a href='"+getNewURI('/stop_points/', true, n.id)+"' > Points d'arrêts </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/stop_areas/', true, n.id)+"' > Zones d'arrêts </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/stop_areas/', true, n.id)+"' > Zones d'arrêts </a>"
         item.innerHTML += "- <a href='"+getNewURI('/vehicle_journeys/', true, n.id)+"' > Circulations </a>"
         worst_disruption = getWorstDisruption(n.links);
         item.innerHTML += getSeverityIcon(worst_disruption);
@@ -760,7 +754,7 @@ function showRoutesHtml(){
             else {newBounds=newBounds.extend(n.layer.getBounds());}
        }
     }
-    if (newBounds) {map.fitBounds(newBounds)}; 
+    if (newBounds) {map.fitBounds(newBounds)};
 }
 
 function showObjectHtml(ptref){

--- a/assets/js/ptref.js
+++ b/assets/js/ptref.js
@@ -321,49 +321,18 @@ function showStopAreasHtml(){
     total.textContent = 'Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count ;
     for (var i in ptref.object_list){
         n=ptref.object_list[i];
-        coord=n.coord;
         var item = ptref_div.appendChild(document.createElement('div'));
-        item.className = 'item';
-        item.innerHTML = "<a class='title' id='item_"+n.id+"' onclick='zoom_to_item("+coord.lat+","+coord.lon+", \""+n.id +"\")'>" + n.label + "</a>";
-        item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br><a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/stop_points/', true, n.id)+"' >Points d'arrêts </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/connections/', true, n.id)+"' > Correspondances </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/departures/', true, n.id)+"' > Prochains départs </a>"
-        item.innerHTML += "- <a href='stop_schedules.html?ws_name="+ws_name+"&coverage="+coverage+"&stop_area_id="+n.id+"' > Horaires </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/places_nearby/', true, n.id)+"' > Autour </a>"
-        worst_disruption = getWorstDisruption(n.links);
-        item.innerHTML += getSeverityIcon(worst_disruption);
 
-        n.marker = L.marker([coord.lat, coord.lon]);
-        lamb=WGS_ED50(coord.lon, coord.lat);
-        try {
-            s_city=n.administrative_regions[0].name;
-        }
-        catch (err) {
-            s_city="no_city";
-        }
+        pt_item = {};
+        pt_item.id = n.id;
+        pt_item.lat = n.coord.lat;
+        pt_item.lon = n.coord.lon;
+        pt_item.label = n.label
+        pt_item.city = n.administrative_regions[0].name || 'no city';
+        pt_item.explo_links = {"Lignes" : getNewURI('/lines/', true, n.id) ,"Points d'arrêts" : getNewURI('/stop_points/', true, n.id) , "Prochains départs" : getNewURI('/departures/', true, n.id) ,"Correspondances" : getNewURI('/connections/', true, n.id), "Horaires" : "stop_schedules.html?ws_name="+ws_name+"&coverage="+coverage+"&stop_area_id="+n.id, "Autour" : getNewURI('/places_nearby/', true, pt_item.id)}
+        pt_item.worst_disruption = getWorstDisruption(n.links);
 
-        n.marker.item_id = "item_" + n.id;
-
-        n.marker.on('click', function(e) {
-            map.panTo([e.latlng.lat, e.latlng.lng]);
-            item = document.getElementById(this.item_id);
-            setActive(item);
-            item.scrollIntoView();
-        });
-
-
-        n.marker.bindPopup(
-            "<b>"+n.name+"</b>"+
-            "<br />"+s_city+
-            "<br />Id: "+n.id+
-            "<br />LatLon wgs84: "+coord.lat + ", "+ coord.lon+
-            "<br />LatLon l2E: "+lamb[0] + ", "+ lamb[1]
-        );
-
-        map.addLayer(n.marker);
-        newBounds.push([coord.lat, coord.lon]);
+        pt_point_item_to_html(item, pt_item);
 
     }
     if (newBounds) {map.fitBounds(newBounds)};
@@ -376,45 +345,15 @@ function showStopPointsHtml(){
     total.textContent = 'Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count ;
     for (var i in ptref.object_list){
         n=ptref.object_list[i];
-        coord=n.coord;
+        pt_item = {};
+        pt_item.id = n.id;
+        pt_item.lat = n.coord.lat;
+        pt_item.lon = n.coord.lon;
+        pt_item.label = n.label
+        pt_item.city = n.administrative_regions[0].name || 'no city';
+        pt_item.explo_links = {"Parcours" : getNewURI('/routes/', true, n.id) ,"Zones d'arrêts" : getNewURI('/stop_areas/', true, n.id) , "Correspondances" : getNewURI('/connections/', true, n.id) , "Autour" : getNewURI('/places_nearby/', true, pt_item.id)}
         var item = ptref_div.appendChild(document.createElement('div'));
-        item.className = 'item';
-        item.innerHTML = "<a class='title' id='item_"+n.id+"' onclick='zoom_to_item("+coord.lat+","+coord.lon+", \""+n.id +"\")'>" + n.label + "</a>";
-        item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br><a href='"+getNewURI('/routes/', true, n.id)+"' > Parcours </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/stop_areas/', true, n.id)+"' >Zones d'arrêts </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/connections/', true, n.id)+"' > Correspondances </a>"
-        item.innerHTML += "- <a href='"+getNewURI('/places_nearby/', true, n.id)+"' > Autour </a>"
-
-        n.marker = L.marker([coord.lat, coord.lon]);
-        lamb=WGS_ED50(coord.lon, coord.lat);
-        try {
-            s_city=n.administrative_regions[0].name;
-        }
-        catch (err) {
-            s_city="no_city";
-        }
-
-        n.marker.item_id = "item_" + n.id;
-
-        n.marker.on('click', function(e) {
-            map.panTo([e.latlng.lat, e.latlng.lng]);
-            item = document.getElementById(this.item_id);
-            setActive(item);
-            item.scrollIntoView();
-        });
-
-
-        n.marker.bindPopup(
-            "<b>"+n.name+"</b>"+
-            "<br />"+s_city+
-            "<br />Id: "+n.id+
-            "<br />LatLon wgs84: "+coord.lat + ", "+ coord.lon+
-            "<br />LatLon l2E: "+lamb[0] + ", "+ lamb[1]
-        );
-
-        map.addLayer(n.marker);
-        newBounds.push([coord.lat, coord.lon]);
+        pt_point_item_to_html(item, pt_item)
 
     }
     if (newBounds) {map.fitBounds(newBounds)};
@@ -485,47 +424,57 @@ function showPOIsHtml(){
     total.textContent = 'Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count ;
     for (var i in ptref.object_list){
         n=ptref.object_list[i];
-        coord=n.coord;
+        pt_item = {};
+        pt_item.id = n.id;
+        pt_item.lat = n.coord.lat;
+        pt_item.lon = n.coord.lon;
+        pt_item.label = n.label
+        pt_item.city = n.administrative_regions[0].name || 'no city';
+        pt_item.explo_links = {"Autour" : getNewURI('/places_nearby/', true, pt_item.id)}
         var item = ptref_div.appendChild(document.createElement('div'));
-        item.className = 'item';
-        item.innerHTML = "<a class='title' id='item_"+n.id+"' onclick='zoom_to_item("+coord.lat+","+coord.lon+", \""+n.id +"\")'>" + n.label + "</a>";
-        item.innerHTML += "<small>" + n.id + "</small>";
-        item.innerHTML += "<br> <a href='"+getNewURI('/places_nearby/', true, n.id)+"' > Autour </a>"
-
-
-        n.marker = L.marker([coord.lat, coord.lon]);
-        lamb=WGS_ED50(coord.lon, coord.lat);
-        try {
-            s_city=n.administrative_regions[0].name;
-        }
-        catch (err) {
-            s_city="no_city";
-        }
-
-        n.marker.item_id = "item_" + n.id;
-
-        n.marker.on('click', function(e) {
-            map.panTo([e.latlng.lat, e.latlng.lng]);
-            item = document.getElementById(this.item_id);
-            setActive(item);
-            item.scrollIntoView();
-        });
-
-
-        n.marker.bindPopup(
-            "<b>"+n.name+"</b>"+
-            "<br />"+s_city+
-            "<br />Id: "+n.id+
-            "<br />LatLon wgs84: "+coord.lat + ", "+ coord.lon+
-            "<br />LatLon l2E: "+lamb[0] + ", "+ lamb[1]
-        );
-
-        map.addLayer(n.marker);
-        newBounds.push([coord.lat, coord.lon]);
+        pt_point_item_to_html(item, pt_item)
 
     }
     if (newBounds) {map.fitBounds(newBounds)};
 
+}
+
+function pt_point_item_to_html(html_elem, pt_info){
+  html_elem.className = 'item';
+  html_elem.innerHTML = "<a class='title' id='item_"+pt_info.id+"' onclick='zoom_to_item("+pt_info.lat+","+pt_info.lon+", \""+pt_info.id +"\")'>" + pt_info.label + "</a>";
+  html_elem.innerHTML += "<small>" + pt_info.id + "</small><br>";
+  for (var a_link in pt_info.explo_links){
+    html_elem.innerHTML += " <a href='"+pt_info.explo_links[a_link]+"' > "+ a_link +" </a> -"
+  }
+  html_elem.innerHTML = html_elem.innerHTML.slice(0,-1);
+
+  if (pt_info.worst_disruption){
+    html_elem.innerHTML += getSeverityIcon(pt_info.worst_disruption);
+  }
+
+  pt_info.marker = L.marker([pt_info.lat, pt_info.lon]);
+  lamb=WGS_ED50(pt_info.lon, pt_info.lat);
+
+  pt_info.marker.item_id = "item_" + pt_info.id;
+
+  pt_info.marker.on('click', function(e) {
+      map.panTo([e.latlng.lat, e.latlng.lng]);
+      html_elem = document.getElementById(this.item_id);
+      setActive(html_elem);
+      html_elem.scrollIntoView();
+  });
+
+
+  pt_info.marker.bindPopup(
+      "<b>"+pt_info.label+"</b>"+
+      "<br />"+pt_info.city+
+      "<br />Id: "+pt_info.id+
+      "<br />LatLon wgs84: "+pt_info.lat + ", "+ pt_info.lon+
+      "<br />LatLon l2E: "+lamb[0] + ", "+ lamb[1]
+  );
+
+  map.addLayer(pt_info.marker);
+  newBounds.push([pt_info.lat, pt_info.lon]);
 }
 
 function showPoiTypesHtml(){

--- a/assets/js/ptref.js
+++ b/assets/js/ptref.js
@@ -132,31 +132,24 @@ function getNewURI(changed_uri, keep_current, current_id) {
 }
 
 function showNetworksHtml(){
-    str="";
-    str+='<table><tr>';
-    str+='<th>Id (Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count + ')</th>';
-    str+='<th>Name</th>';
-    str+='<th>Explorer</th>';
-    str+='<th></th>';
-    str+='</tr>';
+    var ptref_div = document.getElementById('ptref_content');
+    var total = ptref_div.appendChild(document.createElement('div'));
+    total.textContent = 'Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count ;
+
     for (var i in ptref.object_list){
         n=ptref.object_list[i];
-        s_str="<tr>";
-        s_str+='<td><a href="'+getNewURI('/networks/'+n.id+'/', false, n.id)+'">'+n.id+'</a></td>';
-        s_str+='<td>'+n.name + "</td>";
-        s_str+='<td><a href="'+getNewURI('/physical_modes/', true, n.id)+'">Modes Ph</a></td>';
-        s_str+='<td><a href="'+getNewURI('/commercial_modes/', true, n.id)+'">Modes Co</a></td>';
-        s_str+='<td><a href="'+getNewURI('/lines/', true, n.id)+'">Lines</a></td>';
-        s_str+='<td><a href="'+getNewURI('/stop_areas/', true, n.id)+'">Zones d\'arrêts</a></td>';
+        var item = ptref_div.appendChild(document.createElement('div'));
+        item.className = 'item';
+        item.innerHTML = "<a class='title'>" + n.name + "</a>";
+        item.innerHTML += "<small>" + n.id + "</small>";
+        item.innerHTML += "<br><a href='"+getNewURI('/physical_modes/', true, n.id)+"' > Modes Ph </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/commercial_modes/', true, n.id)+"' >Modes co </a>"
+        item.innerHTML += "- <a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/stop_areas/', true, n.id)+"' > Zones d'arrêts </a>"
         worst_disruption = getWorstDisruption(n.links);
-        s_str+='<td>'+getSeverityIcon(worst_disruption)+'</td>';
-        s_str+="</tr>\n";
-        str+=s_str;
-    }
-    str+='</table>'
-    document.getElementById('ptref_content').innerHTML=str;
+        item.innerHTML += getSeverityIcon(worst_disruption);
+    } 
 }
-
 
 
 function showCalendarsHtml(){
@@ -314,34 +307,28 @@ function showModesHtml(){
     str+='</table>'
     document.getElementById('ptref_content').innerHTML=str;
 }
-
 function showStopAreasHtml(){
     newBounds=[];
-    str="";
-    str+='<table><tr>';
-    str+='<th>Id (Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count + ')</th>';
-    str+='<th>Label</th>';
-    str+='<th>Explorer</th>';
-    str+='<th></th>';
-    str+='</tr>';
+    var ptref_div = document.getElementById('ptref_content');
+    var total = ptref_div.appendChild(document.createElement('div'));
+    total.textContent = 'Nb : ' + ptref.object_list.length + ' / ' + ptref.object_count ;
     for (var i in ptref.object_list){
         n=ptref.object_list[i];
-        s_str="<tr>";
-        s_str+='<td><a href="'+getNewURI('', true, n.id)+'">'+n.id+'</a></td>';
-        s_str+='<td>'+n.label + "</td>";
-        s_str+='</td>';
-        s_str+='<td><a href="'+getNewURI('/lines/', true, n.id)+'">Lignes</a></td>';
-        s_str+='<td><a href="'+getNewURI('/stop_points/', true, n.id)+'">StopPoints</a></td>';
-        s_str+='<td><a href="'+getNewURI('/connections/', true, n.id)+'">Corresp.</a></td>';
-        s_str+='<td><a href="'+getNewURI('/departures/', true, n.id)+'">Depart.</a></td>';
-        s_str+='<td><a href="stop_schedules.html?ws_name='+ws_name+'&coverage='+coverage+'&stop_area_id='+n.id+'">Horaires</a></td>';
-        s_str+='<td><a href="'+getNewURI('/places_nearby/', true, n.id)+'">Nearby</a></td>';
-        worst_disruption = getWorstDisruption(n.links);
-        s_str+='<td>'+getSeverityIcon(worst_disruption)+'</td>';
-        s_str+="</tr>\n";
-        str+=s_str;
         coord=n.coord;
-        n.marker = L.marker([coord.lat, coord.lon]).addTo(map);
+        var item = ptref_div.appendChild(document.createElement('div'));
+        item.className = 'item';
+        item.innerHTML = "<a class='title' id='item_"+n.id+"' onclick='zoom_to_item("+coord.lat+","+coord.lon+", \""+n.id +"\")'>" + n.label + "</a>";
+        item.innerHTML += "<small>" + n.id + "</small>";
+        item.innerHTML += "<br><a href='"+getNewURI('/lines/', true, n.id)+"' > Lignes </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/stop_points/', true, n.id)+"' >Points d'arrêts </a>"
+        item.innerHTML += "- <a href='"+getNewURI('/connections/', true, n.id)+"' > Correspondances </a>"  
+        item.innerHTML += "- <a href='"+getNewURI('/departures/', true, n.id)+"' > Prochains départs </a>"
+        item.innerHTML += "- <a href='stop_schedules.html?ws_name="+ws_name+"&coverage="+coverage+"&stop_area_id="+n.id+"' > Horaires </a>"
+        item.innerHTML += "- <a href='"+getNewURI('/places_nearby/', true, n.id)+"' > Autour </a>"
+        worst_disruption = getWorstDisruption(n.links);
+        item.innerHTML += getSeverityIcon(worst_disruption);
+                    
+        n.marker = L.marker([coord.lat, coord.lon]);
         lamb=WGS_ED50(coord.lon, coord.lat);
         try {
             s_city=n.administrative_regions[0].name;
@@ -350,6 +337,16 @@ function showStopAreasHtml(){
             s_city="no_city";
         }
 
+        n.marker.item_id = "item_" + n.id;
+        
+        n.marker.on('click', function(e) {
+            map.panTo([e.latlng.lat, e.latlng.lng]);
+            item = document.getElementById(this.item_id);
+            setActive(item);
+            item.scrollIntoView();
+        });
+        
+            
         n.marker.bindPopup(
             "<b>"+n.name+"</b>"+
             "<br />"+s_city+
@@ -357,16 +354,28 @@ function showStopAreasHtml(){
             "<br />LatLon wgs84: "+coord.lat + ", "+ coord.lon+
             "<br />LatLon l2E: "+lamb[0] + ", "+ lamb[1]
         );
+        
         map.addLayer(n.marker);
-        if (i==0) { map.setView([coord.lat, coord.lon]);}
-
         newBounds.push([coord.lat, coord.lon]);
+        
     }
-    str+='</table>'
-    document.getElementById('ptref_content').innerHTML=str;
     if (newBounds) {map.fitBounds(newBounds)};
 }
 
+function zoom_to_item(lat, lon, _id){
+      map.setView([lat,lon],19);
+      item = document.getElementById("item_" + _id);
+      setActive(item);
+}
+function setActive(el) {
+    var ptref_div = document.getElementById('ptref_content');
+    var all_items = ptref_div.getElementsByTagName('div');
+    for (var i = 0; i < all_items.length; i++) {
+      all_items[i].className = all_items[i].className
+      .replace(/active/, '').replace(/\s\s*$/, '');
+    }
+    el.parentNode.className += ' active';
+}
 function showStopPointsHtml(){
     newBounds=[];
     str="";

--- a/assets/js/ptref.js
+++ b/assets/js/ptref.js
@@ -327,8 +327,10 @@ function showStopAreasHtml(){
         pt_item.id = n.id;
         pt_item.lat = n.coord.lat;
         pt_item.lon = n.coord.lon;
-        pt_item.label = n.label
-        pt_item.city = n.administrative_regions[0].name || 'no city';
+        pt_item.label = n.label;
+        pt_item.city = 'no city';
+        if (n.administrative_regions) {pt_item.city = n.administrative_regions[0].name;}
+
         pt_item.explo_links = {"Lignes" : getNewURI('/lines/', true, n.id) ,"Points d'arrêts" : getNewURI('/stop_points/', true, n.id) , "Prochains départs" : getNewURI('/departures/', true, n.id) ,"Correspondances" : getNewURI('/connections/', true, n.id), "Horaires" : "stop_schedules.html?ws_name="+ws_name+"&coverage="+coverage+"&stop_area_id="+n.id, "Autour" : getNewURI('/places_nearby/', true, pt_item.id)}
         pt_item.worst_disruption = getWorstDisruption(n.links);
 

--- a/places_nearby.html
+++ b/places_nearby.html
@@ -10,16 +10,16 @@
       <div id="params_div"></div>
       <form name="form">
           <nav id="menu_div"></nav>
+          <div id="params">
+             <h1>Recherche à Proximité</h1>
+             <label for="point_name">Zone d'arrêt : </label>
+             <input id="point_name" name="point_name" type="text">      <input id="point_id" name="point_id" type="hidden"> 
+             distance: <input type="text" name="distance" id="distance" value="500">
+             <input type="button" value="Rechercher" onclick="document.forms[0].submit()">
+          </div>
       </form>
   </header>
   <div>
-    <h1>Recherche à Proximité</h1>
-    <div id="params">
-        <label for="point_name">Zone d'arrêt : </label>
-        <input id="point_name" name="point_name" type="text">      <input id="point_id" name="point_id" type="hidden">
-        distance: <input type="text" name="distance" id="distance" value="500">
-        <input type="button" value="Rechercher" onclick="document.forms[0].submit()">
-    </div>
     <!-- <div id="ariane_content">Ariane : <div id="ariane" style="display:inline;"></div></div>  TODO -->
     <div id="content">
         <section class="first_half">

--- a/places_nearby.html
+++ b/places_nearby.html
@@ -6,35 +6,37 @@
     <link rel="stylesheet" href="./assets/jquery-ui.js_1.11.4/jquery-ui.css">
 </head>
 <body onload="places_nearby_onLoad();">
-    <div id="params_div"></div>
-    <form id="form1">
-        <div id="menu_div">    </div>
-        <div id="params">
-            <h1>Recherche à Proximité</h1>
-            <label for="point_name">Zone d'arrêt : </label>
-            <input id="point_name" name="point_name" type="text">      <input id="point_id" name="point_id" type="hidden"> 
-            distance: <input type="text" name="distance" id="distance" value="500">
-            <input type="button" value="Rechercher" onclick="document.forms[0].submit()">
-        </div>
-    </form>
-    <div id="content">
-        <table width="100%" height="500px" border="1">
-            <tr>
-                <td width="50%" valign="top"  style="overflow:scroll;">
-                    <div id="places_div"></div>
-                </td>
-                <td width="50%">
-                    <div id="map-canvas"  style="width:100%;height: 100%"></div>
-                </td>
-            </tr>
-        </table>
-        <div>
+  <header>
+      <div id="params_div"></div>
+      <form name="form">
+          <nav id="menu_div"></nav>
+      </form>
+  </header>
+  <div>
+    <h1>Recherche à Proximité</h1>
+    <div id="params">
+        <label for="point_name">Zone d'arrêt : </label>
+        <input id="point_name" name="point_name" type="text">      <input id="point_id" name="point_id" type="hidden">
+        distance: <input type="text" name="distance" id="distance" value="500">
+        <input type="button" value="Rechercher" onclick="document.forms[0].submit()">
     </div>
-    <div id="footer" class="footer">
-        github: <a href="https://github.com/canaltp/navitia-explorer">canaltp/navitia-explorer</a><br/>            
+    <!-- <div id="ariane_content">Ariane : <div id="ariane" style="display:inline;"></div></div>  TODO -->
+    <div id="content">
+        <section class="first_half">
+            <div id="places_div"></div>
+        </section><!--
+        do not remove !
+        --><section class="second_half">
+          <div id="map-canvas" class="map-canvas"></div>
+        </section>
+    </div>
+
+    <footer id="footer" class="footer">
+        github: <a href="https://github.com/canaltp/navitia-explorer">canaltp/navitia-explorer</a><br/>
         <a href="http://www.navitia.io/"><img src='./assets/img/Navitia_logo.png'></a>
         <a href="http://www.canaltp.fr/"><img src='./assets/img/canaltp_logo.png' ></a>
-    </div>    
+    </footer>
+
     <script type="text/javascript" src="./assets/jquery/jquery-1.11.0.min.js"></script>
     <script type="text/javascript" src="./assets/jquery-ui.js_1.11.4/jquery-ui.js"></script>
     <script type="text/javascript" src="./assets/leaflet_0.7.7/leaflet.js"></script>

--- a/ptref.html
+++ b/ptref.html
@@ -15,14 +15,12 @@
     </header>
 
     <div id="content" >
-        <div id="params1" style="margin:0px;padding:0px;"></div>
-
-        <h1 style="text-align:center;padding:0px;margin:0px">Exploration des données</h1>
+        <h1>Exploration des données</h1>
         <h2>
             <a href="" onclick="changeURI('/networks/','', '')"> Réseaux </a>-
             <a href="" onclick="changeURI('/commercial_modes/','', '')"> Modes commerciaux </a> -
             <a href="" onclick="changeURI('/physical_modes/','', '')"> Modes physiques </a> -
-            <a href="" onclick="changeURI('/poi_types/','', '')"> Pois </a> -
+            <a href="" onclick="changeURI('/poi_types/','', '')"> POIs </a> -
             <a href="" onclick="changeURI('/calendars/','', '')"> Calendriers </a> -
             <a href="" onclick="changeURI('/traffic_reports/','', '')"> État du trafic </a>  
         </h2>    

--- a/ptref.html
+++ b/ptref.html
@@ -6,14 +6,16 @@
     <link rel="stylesheet" href="./assets/jquery-ui.js_1.11.4/jquery-ui.css" />
 </head>
 <body onload="ptref_onLoad();">
-    <div id="params_div"></div>
-    <form name="form">
-        <div id="menu_div"></div>
-        <input type="hidden" id="uri" name="uri" value="">
-    </form>
+    <header>
+        <div id="params_div"></div>
+        <form name="form">
+            <nav id="menu_div"></nav>
+            <input type="hidden" id="uri" name="uri" value="">
+        </form>
+    </header>
+
     <div id="content" >
-        <div id="params1" style="margin:0px;padding:0px;">
-        </div>
+        <div id="params1" style="margin:0px;padding:0px;"></div>
 
         <h1 style="text-align:center;padding:0px;margin:0px">Exploration des données</h1>
         <input type="button" value="Voir les réseaux" onclick="changeURI('/networks/','', '')">
@@ -23,22 +25,19 @@
         <input type="button" value="Voir les calendars" onclick="changeURI('/calendars/','', '')">
         <input type="button" value="Voir l'état du trafic" onclick="changeURI('/traffic_reports/','', '')">
         <div id="ariane_content">Ariane : <div id="ariane" style="display:inline;"></div></div>
-        <table width="100%" height="500px" border="1">
-            <tr>
-                <td width="50%" valign="top">
+        <section class="first_half">
             <div id="ptref_content"></div>
-                </td>
-                <td width="50%">
-            <div id="map-canvas"  style="height: 100%;width:100%"></div>
-                </td>
-            </tr>
-        </table>
+        </section><!--
+        do not remove !
+        --><section class="second_half">
+          <div id="map-canvas" class="map-canvas"></div>
+        </section>
     </div>
-    <div id="footer" class="footer">
+    <footer id="footer" class="footer">
         github: <a href="https://github.com/canaltp/navitia-explorer">canaltp/navitia-explorer</a><br/>            
         <a href="http://www.navitia.io/"><img src='./assets/img/Navitia_logo.png'></a>
         <a href="http://www.canaltp.fr/"><img src='./assets/img/canaltp_logo.png' ></a>
-    </div>    
+    </footer>    
     <script type="text/javascript" src="./assets/jquery/jquery-1.11.0.min.js"></script>
     <script type="text/javascript" src="./assets/jquery-ui.js_1.11.4/jquery-ui.js"></script>
     <script type="text/javascript" src="./assets/leaflet_0.7.7/leaflet.js"></script>

--- a/ptref.html
+++ b/ptref.html
@@ -18,12 +18,15 @@
         <div id="params1" style="margin:0px;padding:0px;"></div>
 
         <h1 style="text-align:center;padding:0px;margin:0px">Exploration des données</h1>
-        <input type="button" value="Voir les réseaux" onclick="changeURI('/networks/','', '')">
-        <input type="button" value="Voir les modes commerciaux" onclick="changeURI('/commercial_modes/','', '')">
-        <input type="button" value="Voir les modes physiques" onclick="changeURI('/physical_modes/','', '')">
-        <input type="button" value="Voir les POI" onclick="changeURI('/poi_types/','', '')">
-        <input type="button" value="Voir les calendars" onclick="changeURI('/calendars/','', '')">
-        <input type="button" value="Voir l'état du trafic" onclick="changeURI('/traffic_reports/','', '')">
+        <h2>
+            <a href="" onclick="changeURI('/networks/','', '')"> Réseaux </a>-
+            <a href="" onclick="changeURI('/commercial_modes/','', '')"> Modes commerciaux </a> -
+            <a href="" onclick="changeURI('/physical_modes/','', '')"> Modes physiques </a> -
+            <a href="" onclick="changeURI('/poi_types/','', '')"> Pois </a> -
+            <a href="" onclick="changeURI('/calendars/','', '')"> Calendriers </a> -
+            <a href="" onclick="changeURI('/traffic_reports/','', '')"> État du trafic </a>  
+        </h2>    
+
         <div id="ariane_content">Ariane : <div id="ariane" style="display:inline;"></div></div>
         <section class="first_half">
             <div id="ptref_content"></div>

--- a/ptref.html
+++ b/ptref.html
@@ -14,7 +14,7 @@
         </form>
     </header>
 
-    <div id="content" >
+    <div>
         <h1>Exploration des données</h1>
         <h2>
             <a href="" onclick="changeURI('/networks/','', '')"> Réseaux </a>-
@@ -26,13 +26,15 @@
         </h2>    
 
         <div id="ariane_content">Ariane : <div id="ariane" style="display:inline;"></div></div>
-        <section class="first_half">
-            <div id="ptref_content"></div>
-        </section><!--
-        do not remove !
-        --><section class="second_half">
-          <div id="map-canvas" class="map-canvas"></div>
-        </section>
+        <div id="content">
+            <section class="first_half">
+                <div id="ptref_content"></div>
+            </section><!--
+            do not remove !
+            --><section class="second_half">
+              <div id="map-canvas" class="map-canvas"></div>
+            </section>
+        </div>
     </div>
     <footer id="footer" class="footer">
         github: <a href="https://github.com/canaltp/navitia-explorer">canaltp/navitia-explorer</a><br/>            


### PR DESCRIPTION
ou "ivre, elle refactore le css de navitia-explorer" :beers: 

J'ai viré le gros tableau qui structurait la page.
J'ai transformé le tableau contenant les éléments de ptref en liste pour
* les réseaux
* les lignes
* les parcours
* les points d'arrêts
* les zones d'arrêts
* les modes commerciaux
* les modes physiques
* les types de POIs 
* les POIs

Ajouts fonctionnels : 
* lors du clic sur un élément sur la carte, l'élément dans la liste est mis en surbrillance
* lors du clic sur un élément dans la liste, zoom sur l'élément sur la carte pour point d'arrêt, zone d'arrêt et POIs (je n'ai pas réussi à le faire sur les lignes et parcours :( )
* on peut afficher cette page de navitia-explorer sur un petit écran